### PR TITLE
Fix typos and rename structures

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # goscriptor
 
-Packet GoScriptor implements a way to use redis script more easily
+Package GoScriptor implements a way to use redis script more easily
 
 ## Install
 

--- a/doc.go
+++ b/doc.go
@@ -1,3 +1,3 @@
 // Package doc is a generated GoDoc package.
-// Packet goscriptor implements a way to use redis script more easily
+// Package goscriptor implements a way to use redis script more easily
 package goscriptor

--- a/redis.go
+++ b/redis.go
@@ -26,12 +26,12 @@ func (opt *Option) Create() redis.UniversalClient {
 	})
 }
 
-// UniversalOprions - Redis Option
-type UniversalOprions redis.UniversalOptions
+// UniversalOptions - Redis Option
+type UniversalOptions redis.UniversalOptions
 
 // CreateAddrs - create a new redis descriptor
 //
 //	https://redis.uptrace.dev/guide/universal.html
-func (opt *UniversalOprions) CreateAddrs() redis.UniversalClient {
+func (opt *UniversalOptions) CreateAddrs() redis.UniversalClient {
 	return redis.NewUniversalClient((*redis.UniversalOptions)(opt))
 }

--- a/script.go
+++ b/script.go
@@ -38,8 +38,8 @@ var (
 
 // Script is a script descriptor
 type ScriptDescriptor struct {
-	contrainer map[string]string
-	Scripts    map[string]string
+	container map[string]string
+	Scripts   map[string]string
 }
 
 // NewScriptDescriptor creates a new script descriptor
@@ -52,7 +52,7 @@ func NewScriptDescriptor(ctx context.Context, client redis.UniversalClient, scri
 	scriptDescriptor := &ScriptDescriptor{}
 
 	if scripts == nil || len(*scripts) == 0 {
-		// Lodad the lua script sha1
+		// Load the lua script sha1
 		err := scriptDescriptor.LoadScripts(ctx, client, redisScriptDefinition, db)
 		if err != nil {
 			return nil, err
@@ -72,7 +72,7 @@ func NewScriptDescriptor(ctx context.Context, client redis.UniversalClient, scri
 
 // Registers a script
 func (scriptDescriptor *ScriptDescriptor) Register(ctx context.Context, client redis.UniversalClient, scripts *map[string]string, redisScriptDefinition string, db int) error {
-	scriptDescriptor.contrainer = make(map[string]string)
+	scriptDescriptor.container = make(map[string]string)
 
 	// Registers a script
 	for name, body := range *scripts {
@@ -84,7 +84,7 @@ func (scriptDescriptor *ScriptDescriptor) Register(ctx context.Context, client r
 		// countinue the script
 		sha1, err = availableLuaScript(ctx, client, redisScriptDefinition, db, name)
 		if err == nil {
-			scriptDescriptor.contrainer[name] = sha1
+			scriptDescriptor.container[name] = sha1
 			continue
 		}
 
@@ -99,7 +99,7 @@ func (scriptDescriptor *ScriptDescriptor) Register(ctx context.Context, client r
 			return err
 		}
 
-		scriptDescriptor.contrainer[name] = sha1
+		scriptDescriptor.container[name] = sha1
 	}
 
 	return nil
@@ -131,7 +131,7 @@ func (scriptDescriptor *ScriptDescriptor) LoadScripts(ctx context.Context, clien
 
 		// Parse the script name and sha1
 		// checking the existence of the scripts in the script cache.
-		scriptDescriptor.contrainer = make(map[string]string)
+		scriptDescriptor.container = make(map[string]string)
 		for i := 0; i < count; i = i + 2 {
 			key, value := v[i], v[i+1]
 
@@ -139,7 +139,7 @@ func (scriptDescriptor *ScriptDescriptor) LoadScripts(ctx context.Context, clien
 			if err != nil {
 				return err
 			}
-			scriptDescriptor.contrainer[key.(string)] = value.(string)
+			scriptDescriptor.container[key.(string)] = value.(string)
 		}
 	}
 	return nil

--- a/scriptor.go
+++ b/scriptor.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-redis/redis/v8"
 )
 
-// redis script defination
+// redis script definition
 // the hash key definition that is used to store the script
 var (
 	scriptDefinition = "scriptor_v.0.0.0"
@@ -58,7 +58,7 @@ func New(client redis.UniversalClient, scriptDB int, redisScriptDefinition strin
 	if err != nil {
 		return nil, err
 	}
-	s.scripts = scriptDescriptor.contrainer
+	s.scripts = scriptDescriptor.container
 
 	return s, nil
 }
@@ -97,7 +97,7 @@ func NewDB(opt *Option, scriptDB int, redisScriptDefinition string, scripts *map
 	if err != nil {
 		return nil, err
 	}
-	s.scripts = scriptDescriptor.contrainer
+	s.scripts = scriptDescriptor.container
 
 	return s, nil
 }


### PR DESCRIPTION
## Summary
- fix typos in documentation and comments
- rename `contrainer` to `container` inside script descriptor
- rename `UniversalOprions` to `UniversalOptions`
- update README wording

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_683febbc08e0832dbdf6ffc34b4011f8